### PR TITLE
Changes to get build script to work on Concourse.

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -45,6 +45,12 @@ resources:
           uri: git@github.com:((github-account.username))/terraform-provider-google.git
           private_key: ((repo-key.private_key))
 
+    - name: terraform-head
+      type: git-branch
+      source:
+          uri: git@github.com:terraform-providers/terraform-provider-google.git
+          private_key: ((repo-key.private_key))
+
     - name: mm-approved-prs
       type: github-pull-request
       source:
@@ -74,7 +80,7 @@ resources:
       source:
         bucket: ((gcp-bucket))
         json_key: ((gcp-bucket-json-key))
-        regexp: dist/terraform-provider-google.(*)
+        regexp: dist/terraform-provider-google.*
 
     - name: night-trigger
       type: time
@@ -260,12 +266,45 @@ jobs:
       plan:
           - get: night-trigger
             trigger: true
-          - get: magic-modules
-          - get: terraform-generated
+          - get: magic-modules-gcp
+          - get: terraform-head
 
           - task: build
-            file: magic-modules/.ci/magic-modules/generate-terraform-all-platforms.yml
+            file: magic-modules-gcp/.ci/magic-modules/generate-terraform-all-platforms.yml
 
           - put: gcp-bucket
             params:
-              file: dist/terraform-provider-google.(*)
+              file: dist/terraform-provider-google.darwin_amd64
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.freebsd_386
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.freebsd_amd64
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.freebsd_arm
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.linux_386
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.linux_amd64
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.linux_arm
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.openbsd_386
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.openbsd_amd64
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.solaris_amd64
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.windows_386.exe
+          - put: gcp-bucket
+            params:
+              file: dist/terraform-provider-google.windows_amd64.exe

--- a/.ci/magic-modules/generate-terraform-all-platforms.sh
+++ b/.ci/magic-modules/generate-terraform-all-platforms.sh
@@ -14,7 +14,7 @@ function init {
   # Create GOPATH structure
   mkdir -p "${GOPATH}/src/github.com/terraform-providers"
   # Copy the repo
-  cp -rf "$1" "${GOPATH}/src/github.com/terraform-providers/"
+  cp -rf "$1" "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google"
   # Paths and vars
   PROVIDER_NAME="google"
   PROVIDERPATH="$GOPATH/src/github.com/terraform-providers"
@@ -24,7 +24,7 @@ function init {
   XC_OS=${XC_OS:=linux darwin windows freebsd openbsd solaris}
   XC_EXCLUDE_OSARCH="!darwin/arm !darwin/386"
   export CGO_ENABLED=0
-  mkdir -p $TARGET_DIR
+  mkdir -p "$TARGET_DIR"
 }
 
 function installGox {
@@ -34,7 +34,7 @@ function installGox {
 }
 
 function compile {
-  pushd $SRC_DIR
+  pushd "$SRC_DIR"
   printf "\n"
   make fmtcheck
 
@@ -45,7 +45,7 @@ function compile {
   rm -f bin/*
   rm -fr pkg/*
   # Build with gox
-  $GOBIN/gox \
+  "$GOBIN/gox" \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \
     -osarch="${XC_EXCLUDE_OSARCH}" \
@@ -57,9 +57,9 @@ function compile {
 }
 
 function main {
-  init $1
+  init "$1"
   installGox
   compile
 }
 
-main
+main "$@"

--- a/.ci/magic-modules/generate-terraform-all-platforms.yml
+++ b/.ci/magic-modules/generate-terraform-all-platforms.yml
@@ -1,8 +1,8 @@
 ---
 platform: linux
 inputs:
-  - name: terraform-generated
-  - name: magic-modules
+  - name: terraform-head
+  - name: magic-modules-gcp
 
 image_resource:
   type: docker-image
@@ -11,9 +11,9 @@ image_resource:
     tag: '1.10'
 
 run:
-  path: magic-modules/.ci/magic-modules/generate-terraform-all-platforms.sh
+  path: magic-modules-gcp/.ci/magic-modules/generate-terraform-all-platforms.sh
   args:
-    - terraform-generated
+    - terraform-head
   
 outputs:
   - name: dist


### PR DESCRIPTION
Here are the changes I made to get the build script working.

* Globs are not supported in `put` for the GCS resource, so we have to list them all explicitly.
* Have to use to right resources (which have slightly misleading names - that's on me.  :) )
* Use quotes in shell scripts to avoid undesired splitting / globbing.

Go ahead and merge this in to your `master` branch, and that will automatically update your PR against GoogleCloudPlatform/magic-modules.